### PR TITLE
Fix memory corruption

### DIFF
--- a/src/hostapi/opensles/pa_opensles.c
+++ b/src/hostapi/opensles/pa_opensles.c
@@ -893,7 +893,7 @@ static PaError InitializeOutputStream(PaOpenslesHostApiRepresentation *openslesH
     (*stream->outputStream->audioPlayer)->GetInterface( stream->outputStream->audioPlayer, SL_IID_PLAY, &stream->outputStream->playerItf );
     (*stream->outputStream->audioPlayer)->GetInterface( stream->outputStream->audioPlayer, SL_IID_ANDROIDSIMPLEBUFFERQUEUE, &stream->outputStream->outputBufferQueueItf );
 
-    stream->outputStream->outputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * stream->outputStream->bytesPerSample );
+    stream->outputStream->outputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * sizeof(void*) );
     for( i = 0; i < numberOfBuffers; ++i )
     {
         stream->outputStream->outputBuffers[i] = (void*) PaUtil_AllocateMemory( stream->framesPerHostCallback * stream->outputStream->bytesPerSample
@@ -995,7 +995,7 @@ static PaError InitializeInputStream( PaOpenslesHostApiRepresentation *openslesH
                                             SL_IID_RECORD,
                                             &stream->inputStream->recorderItf );
 
-    stream->inputStream->inputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * stream->inputStream->bytesPerSample );
+    stream->inputStream->inputBuffers = (void **) PaUtil_AllocateMemory( numberOfBuffers * sizeof(void*) );
     for( i = 0; i < numberOfBuffers; ++i )
     {
         stream->inputStream->inputBuffers[i] = (void*) PaUtil_AllocateMemory( stream->framesPerHostCallback


### PR DESCRIPTION
The size of a pointer is always fixed regardless of the data format chosen.

This causes corruption & random crashes if the chosen format is int16 or int8